### PR TITLE
feat(view): Adiciona página de consulta de hierarquia e divisas

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,21 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+    images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'tiahnwnyredges0d.public.blob.vercel-storage.com',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
+
+
 export default nextConfig;
+
+
+ 

--- a/prisma/migrations/20250926210747_adiciona_url_divisa_cargo/migration.sql
+++ b/prisma/migrations/20250926210747_adiciona_url_divisa_cargo/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Cargo` ADD COLUMN `divisaUrl` VARCHAR(191) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -118,6 +118,7 @@ model Cargo {
   precedencia Int            @unique
   classe      ClasseOficial?
   usuarios    User[]
+  divisaUrl   String?
 }
 
 model Funcao {

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -1,7 +1,6 @@
-// src/app/(main)/profile/page.tsx
 import { getFullCurrentUser } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import ProfileClient from "./ProfileClient"; // Importa nosso novo componente de UI
+import ProfileClient from "./ProfileClient"; 
 
 export default async function ProfilePage() {
   const user = await getFullCurrentUser();

--- a/src/app/(main)/quadros/page.tsx
+++ b/src/app/(main)/quadros/page.tsx
@@ -1,0 +1,117 @@
+import prisma from "@/lib/prisma";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import Image from "next/image";
+
+async function getCargosDoQuadro() {
+    return await prisma.cargo.findMany({
+        where: {
+            categoria: 'QUADRO',
+        },
+        orderBy: {
+            precedencia: 'asc'
+        }
+    });
+}
+
+export default async function HierarquiaPage() {
+    const todosCargos = await getCargosDoQuadro();
+
+    const oficiais = todosCargos.filter(c => c.tipo === 'POSTO');
+    const pracas = todosCargos.filter(c => c.tipo === 'GRADUACAO');
+
+    return (
+        <div className="container mx-auto py-10 max-w-7xl">
+            <div className="mb-8">
+                <h1 className="text-3xl font-bold tracking-tight">Hierarquia e Divisas</h1>
+                <p className="text-muted-foreground">Consulte a hierarquia, abreviações e divisas dos cargos da Guarda Mirim.</p>
+            </div>
+
+            <section className="mb-12">
+                <h2 className="text-2xl font-semibold flex items-center gap-3 mb-4">
+                    Quadro de Oficiais (QOGM)
+                </h2>
+
+      
+                <div className="relative w-full overflow-auto border rounded-lg ">
+                    <Table className="bg-card">
+                        <TableHeader className="bg-muted">
+                            <TableRow>
+                               <TableHead className="w-[300px] align-middle text-center border-r">Posto</TableHead>
+                               <TableHead className="w-[280px] align-middle border-r text-center">Abreviação</TableHead>
+                               <TableHead className="w-[250px] align-middle border-r text-center">Número</TableHead>
+                               <TableHead className="align-middle text-center">Divisa</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {oficiais.map(cargo => (
+                                <TableRow key={cargo.id}>
+                                    <TableCell className="font-medium whitespace-nowrap border-r text-center">{cargo.nome}</TableCell>
+                                    <TableCell className="border-r text-center">{cargo.abreviacao}</TableCell>
+                                    <TableCell className="border-r text-center">
+                                        {cargo.codigo ? String(cargo.codigo).padStart(2, '0') : '-'}
+                                    </TableCell>
+                                    <TableCell className="flex items-center justify-center">
+                                        <div className="w-40 h-16 bg-muted/50 rounded-md flex items-center justify-center ">
+                                            {cargo.divisaUrl ? (
+                                                <Image src={cargo.divisaUrl} alt={`Divisa de ${cargo.nome}`} width={100} height={64} style={{ objectFit: 'contain' }} />
+                                            ) : (
+                                                <span className="text-xs text-muted-foreground">Sem imagem</span>
+                                            )}
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </div>
+            </section>
+            
+            <section>
+                <h2 className="text-2xl font-semibold flex items-center gap-3 mb-4">
+                    Quadro de Praças (QPGM)
+                </h2>
+                <div className="relative w-full overflow-auto border rounded-lg ">
+                    <Table className="bg-card">
+                        <TableHeader className="bg-muted">
+                            <TableRow>
+                                <TableHead className="w-[300px] align-middle text-center border-r">Graduação</TableHead>
+                                <TableHead className="w-[280px] align-middle border-r text-center">Abreviação</TableHead>
+                                <TableHead className="w-[250px] align-middle border-r text-center">Número</TableHead>
+                                <TableHead className="align-middle text-center">Divisa</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {pracas.map(cargo => (
+                                <TableRow key={cargo.id}>
+                                    <TableCell className="font-medium whitespace-nowrap border-r text-center">
+                                        <div>
+                                            <span>{cargo.nome}</span>
+                                            {cargo.nome.toUpperCase() === 'ASPIRANTE' && (
+                                                <p className="text-xs text-muted-foreground mt-1">
+                                                    (Praça em situação especial)
+                                                </p>
+                                            )}
+                                        </div>
+                                    </TableCell>
+                                    <TableCell className="border-r text-center">{cargo.abreviacao}</TableCell>
+                                    <TableCell className="border-r text-center">
+                                        {cargo.codigo ? String(cargo.codigo).padStart(2, '0') : '-'}
+                                    </TableCell>
+                                    <TableCell className="flex items-center justify-center">
+                                        <div className="w-40 h-16 bg-muted/50 rounded-md flex items-center justify-center">
+                                            {cargo.divisaUrl ? (
+                                                <Image src={cargo.divisaUrl} alt={`Divisa de ${cargo.nome}`} width={100} height={64} style={{ objectFit: 'contain' }} />
+                                            ) : (
+                                                <span className="text-xs text-muted-foreground">Sem imagem</span>
+                                            )}
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </div>
+            </section>
+        </div>
+    );
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/sheet";
 import { 
   ChevronDown, Home, FileText, Calendar, User, ClipboardCheck, 
-  FileWarning, ClipboardList, Menu
+  FileWarning, TableProperties,ClipboardList, Menu
 } from "lucide-react";
 import { UserNav } from "@/components/UserNav";
 import Image from 'next/image';
@@ -48,6 +48,7 @@ const menuGroups = [
     links: [
       { href: "/regulations", label: "Regulamento", icon: FileText },
       { href: "#", label: "Calendário de Eventos", icon: Calendar },
+      { href: "/quadro", label: "QOGM e QPGM", icon: TableProperties  },
     ]
   }
 ];
@@ -88,6 +89,7 @@ export function Header({ user }: { user: User | null }) {
             <DropdownMenuContent>
               <DropdownMenuItem asChild><Link href="/regulations" className="flex items-center w-full cursor-pointer"><FileText className="mr-2 h-4 w-4" /><span>Regulamento</span></Link></DropdownMenuItem>
               <DropdownMenuItem asChild><Link href="#" className="flex items-center w-full cursor-pointer"><Calendar className="mr-2 h-4 w-4" /><span>Calendário de Eventos</span></Link></DropdownMenuItem>
+              <DropdownMenuItem asChild><Link href="/quadros" className="flex items-center w-full cursor-pointer"><TableProperties className="mr-2 h-4 w-4" /><span>QOGM e QPGM</span></Link></DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </nav>


### PR DESCRIPTION
Este PR introduz a nova página "Hierarquia e Divisas", destinada à consulta pública dos alunos. A página exibe a estrutura hierárquica dos quadros de oficiais (QOGM) e praças (QPGM) da Guarda Mirim.

##  Alterações Realizadas

- **Nova Página (`/hierarquia`):**
  - Busca todos os cargos da categoria `QUADRO` no banco de dados.
  - Exibe os cargos em duas tabelas separadas (Oficiais e Praças), ordenadas pela `precedencia` hierárquica.
  - A tabela inclui as colunas: Posto/Graduação, Abreviação, Número (código) e um espaço reservado para a imagem da Divisa.
  - Implementa a responsividade para dispositivos móveis, permitindo o scroll horizontal da tabela.

- **Banco de Dados (`schema.prisma`):**
  - O campo `codigo` no modelo `Cargo` foi tornado opcional para acomodar cargos sem número.
  - Adicionado o campo opcional `divisaUrl` para futuras implementações de imagens de divisas.

- **Navegação:**
  - Adicionado um link de acesso à nova página no menu "Institucional" do header principal.

##  Como Testar

1.  Acessar a nova página através do menu "Institucional" > "Hierarquia e Divisas".
2.  Verificar se as tabelas de Oficiais e Praças são exibidas na ordem hierárquica correta.
3.  Confirmar que as colunas (Posto/Graduação, Abreviação, Número, Divisa) estão corretas.
4.  Testar a visualização em uma tela de celular para confirmar que o scroll horizontal da tabela funciona.